### PR TITLE
Use Gradle version 6.0.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip


### PR DESCRIPTION
I was unable to run it on the latest MacOS (Monterey):

```
FAILURE: Build failed with an exception.

* What went wrong:
Could not determine java version from '11.0.12'.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.
```

Switching to 6.0.1 helped.